### PR TITLE
Store androlog reports in a subdirectory on the SDCard

### DIFF
--- a/androlog/src/main/java/de/akquinet/android/androlog/reporter/MailReporter.java
+++ b/androlog/src/main/java/de/akquinet/android/androlog/reporter/MailReporter.java
@@ -82,8 +82,11 @@ public class MailReporter implements EnhancedReporter {
             String reportStr = report.asJSON()
                     .toString();
             
+            // Create androlog folder
+            File andrologFolder = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/androlog");
+            andrologFolder.mkdir();
             String reportFilePath =
-                    Environment.getExternalStorageDirectory().getAbsolutePath()
+                    andrologFolder.getPath()
                             + "/androlog-report-" + createReportFilenameSuffix(context, report) + ".json";
 
             Intent intent = new Intent(Intent.ACTION_SEND);


### PR DESCRIPTION
Androlog reports are stored in a subdirectory on the sdcard when using the MailReporter, reducing clutter and avoiding the FAT base-directory file limit (see http://stackoverflow.com/questions/2651907/is-there-a-limit-for-the-number-of-files-in-a-directory-on-an-sd-card)
