### PR TITLE
The check to keep the number of log entries under a configured maximum d...

### DIFF
--- a/androlog-it/pom.xml
+++ b/androlog-it/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>de.akquinet.android.androlog</groupId>
     <artifactId>androlog-project</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+      <version>1.0.7-kherink.1</version>
   </parent>
 
   <artifactId>androlog-it</artifactId>

--- a/androlog/pom.xml
+++ b/androlog/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>de.akquinet.android.androlog</groupId>
     <artifactId>androlog-project</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.7-kherink.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/androlog/src/main/java/de/akquinet/android/androlog/Log.java
+++ b/androlog/src/main/java/de/akquinet/android/androlog/Log.java
@@ -1228,7 +1228,7 @@ public class Log {
      * @param err
      *            the error message
      */
-    private static void collectLogEntry(int level, String tag, final String message,
+    private static synchronized void collectLogEntry(int level, String tag, final String message,
             final Throwable err) {
         if (!isReportable(level)) {
             return;

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>de.akquinet.android.androlog</groupId>
     <artifactId>androlog-project</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.7-kherink.1</version>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
...oesn't work reliably in a multithreaded environment.

Discovered this courtesy of OOM exception:

01-31 01:17:03.169  24220-24220/com.paloma.photochat E/dalvikvm-heap﹕ Out of memory on a 25459364-byte allocation.
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ "main" prio=5 tid=1 RUNNABLE JIT
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ | group="main" sCount=0 dsCount=0 obj=0x40209178 self=0xcf80
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ | sysTid=24220 nice=0 sched=0/0 cgrp=default handle=-1345006336
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ | schedstat=( 9779331033 5074622607 4664 )
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at java.lang.AbstractStringBuilder.enlargeBuffer(AbstractStringBuilder.java:~95)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at java.lang.AbstractStringBuilder.append0(AbstractStringBuilder.java:140)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at java.lang.StringBuilder.append(StringBuilder.java:125)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at org.json.JSONStringer.string(JSONStringer.java:344)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at org.json.JSONStringer.value(JSONStringer.java:252)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at org.json.JSONArray.writeTo(JSONArray.java:572)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at org.json.JSONStringer.value(JSONStringer.java:233)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at org.json.JSONObject.writeTo(JSONObject.java:667)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at org.json.JSONStringer.value(JSONStringer.java:237)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at org.json.JSONObject.writeTo(JSONObject.java:667)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at org.json.JSONObject.toString(JSONObject.java:636)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at de.akquinet.android.androlog.reporter.MailReporter.send(MailReporter.java:82)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at de.akquinet.android.androlog.Log.report(Log.java:1206)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at de.akquinet.android.androlog.Log$1.uncaughtException(Log.java:453)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:854)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:851)
01-31 01:17:03.169  24220-24220/com.paloma.photochat I/dalvikvm﹕ at dalvik.system.NativeStart.main(Native Method)

configured 1500 entries and ended up with 45000.
Synchronizing the Log.collectLogEntry(..) method is one possible solutions, another solution may be to turn the check from an "if" to a "while" loop.
